### PR TITLE
One child fix

### DIFF
--- a/Compiler.coffee
+++ b/Compiler.coffee
@@ -70,11 +70,11 @@ class Compiler
         props.className = className
 
       React.cloneElement child, props,
-        if React.Children.count child.props.children > 1
+        if React.Children.count child.props.children is 1
+          @traverseChild React.Children.only child.props.children
+        else
           React.Children.map child.props.children, (child) =>
             @traverseChild child, parentClass
-        else
-          @traverseChild React.Children.only child.props.children
     else
       child
 

--- a/Compiler.coffee
+++ b/Compiler.coffee
@@ -71,7 +71,7 @@ class Compiler
 
       React.cloneElement child, props,
         if React.Children.count child.props.children is 1
-          @traverseChild React.Children.only child.props.children
+          @traverseChild React.Children.only child.props.children, parentClass
         else
           React.Children.map child.props.children, (child) =>
             @traverseChild child, parentClass

--- a/Compiler.coffee
+++ b/Compiler.coffee
@@ -71,7 +71,7 @@ class Compiler
 
       React.cloneElement child, props,
         if React.Children.count child.props.children is 1
-          @traverseChild React.Children.only child.props.children, parentClass
+          @traverseChild React.Children.only(child.props.children), parentClass
         else
           React.Children.map child.props.children, (child) =>
             @traverseChild child, parentClass

--- a/Compiler.coffee
+++ b/Compiler.coffee
@@ -70,8 +70,11 @@ class Compiler
         props.className = className
 
       React.cloneElement child, props,
-        React.Children.map child.props.children, (child) =>
-          @traverseChild child, parentClass
+        if React.Children.count child.props.children > 1
+          React.Children.map child.props.children, (child) =>
+            @traverseChild child, parentClass
+        else
+          @traverseChild React.Children.only child.props.children
     else
       child
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bluecore-classnames",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Automatic class builder for React components",
   "keywords": [
     "react",


### PR DESCRIPTION
Some components which expect a single child and use React.Children.only will fail if their children are passed from the result of React.Children.map. Here's an issue describing this: https://github.com/facebook/react/issues/4424
To fix this, I check the number of childrens while traversing the tree, and if it's 1 I use React.Children.only instead of React.Children.map.